### PR TITLE
Fix/history wrong variants

### DIFF
--- a/consensus/ConsensusFileGenerator.py
+++ b/consensus/ConsensusFileGenerator.py
@@ -21,7 +21,8 @@ class ConsensusFileGenerator:
         comments_table = tables['comments_table']
         self.consensus_data = data['consensus_data']
         self.lab_classifications = data['lab_classifications']
-        self.history = data['history']
+        self.history = data['history']['history']
+        self.alternative_history = data['history']['alternative']
         self.consensus_table_file_name = consensus_table
         self.comments_table_file_name = comments_table
 
@@ -165,6 +166,13 @@ class ConsensusFileGenerator:
                 variant_history = self._add_history_of_variant(possible_id + '_dup0', export, variant_history)
                 variant_history = self._add_history_of_variant(possible_id + '_dup1', export, variant_history)
 
+            alternative_history = self.alternative_history[export_id]
+            if 'transcript' in variant and 'c_dna' in variant:
+                variant_id = self._check_alternative_history(variant['transcript'], variant['c_dna'], gene,
+                                                             alternative_history)
+                if variant_id and variant_id not in variant_history:
+                    variant_history.append(variant_id)
+
         return variant_history
 
     def _create_consensus_line(self, variant_id, variant, variant_lab_classifications, labs):
@@ -246,3 +254,9 @@ class ConsensusFileGenerator:
         comments_file.close()
         progress_bar.finish()
         return consensus_file_name, comments_file_name
+
+    @staticmethod
+    def _check_alternative_history(transcript, c_dna, gene, export):
+        variant = '{}_{}:{}'.format(gene, transcript, c_dna)
+        if variant in export:
+            return export[variant]

--- a/consensus/ConsensusFileGenerator.py
+++ b/consensus/ConsensusFileGenerator.py
@@ -178,9 +178,10 @@ class ConsensusFileGenerator:
                                                              alternative_history)
                 if variant_id and variant_id not in variant_history:
                     variant_history.append(variant_id)
-                    message = '{} is invalid; will be replaced by correct variant {} in future releases\n'.format(
+                    message = '{} is invalid; will be replaced by correct variant {}\n'.format(
                         variant_id, variant['id'])
-                    incorrect_history_file.write('{},{}'.format(variant_id, message))
+                    if incorrect_history_file:
+                        incorrect_history_file.write('{},{}'.format(variant_id, message))
 
         if incorrect_history_file:
             incorrect_history_file.close()

--- a/consensus/HistorySorter.py
+++ b/consensus/HistorySorter.py
@@ -1,11 +1,13 @@
 class HistorySorter:
     """The HistorySorter sorts the history by export"""
+
     def __init__(self, history_data, previous_exports):
         """
         :param history_data: the complete content of the history table
         :param previous_exports: a list of ids of previous exports (format: yymm, 1810 is october 2018)
         """
         self.sorted_history = {export: [] for export in previous_exports}
+        self.alternative_history = {export: {} for export in previous_exports}
         self.sort_history(history_data)
 
     def sort_history(self, unsorted_history):
@@ -16,3 +18,7 @@ class HistorySorter:
         for variant in unsorted_history:
             export = variant['id'].split('_')[0]
             self.sorted_history[export].append(variant['id'])
+            if 'c_dna' in variant and 'transcript' in variant and '{}_{}:{}'.format(
+                    variant['gene'], variant['transcript'], variant['c_dna']) not in self.alternative_history[export]:
+                self.alternative_history[export]['{}_{}:{}'.format(
+                    variant['gene'], variant['transcript'], variant['c_dna'])] = variant['id']

--- a/consensus/__main__.py
+++ b/consensus/__main__.py
@@ -15,6 +15,8 @@ def main():
     molgenis_server = molgenis.Session(config.server)
     history_table = config.history
     previous_exports = config.previous
+    if type(previous_exports) != list:
+        previous_exports = [previous_exports]
     output = config.output
 
     # Login on molgenis server
@@ -28,7 +30,9 @@ def main():
 
     # Sort history on export
     history = retriever.history
-    sorted_history = HistorySorter(history, previous_exports).sorted_history
+    history_sorter = HistorySorter(history, previous_exports)
+    sorted_history = history_sorter.sorted_history
+    alternative_history = history_sorter.alternative_history
 
     # Generate consensus table in memory
     consensus_generator = ConsensusTableGenerator(lab_data)
@@ -37,7 +41,7 @@ def main():
 
     # Generate and upload CSV with consensus table
     file_generator = ConsensusFileGenerator(
-        data={'consensus_data': consensus, 'lab_classifications': lab_classifications, 'history': sorted_history},
+        data={'consensus_data': consensus, 'lab_classifications': lab_classifications, 'history': {'history': sorted_history, 'alternative': alternative_history}},
         tables={'consensus_table': output + consensus_table, 'comments_table': output + comments_table})
     file_generator.generate_consensus_files()
 

--- a/consensus/__main__.py
+++ b/consensus/__main__.py
@@ -1,4 +1,6 @@
 from molgenis import client as molgenis
+from termcolor import colored
+
 from consensus.DataRetriever import DataRetriever
 from consensus.ConsensusTableGenerator import ConsensusTableGenerator
 from consensus.MolgenisConfigParser import MolgenisConfigParser as ConfigParser
@@ -9,7 +11,7 @@ from consensus.ConsensusFileGenerator import ConsensusFileGenerator
 
 def main():
     # Get data from config
-    config = ConfigParser('config/config.txt') # To run by pressing play in pycharm, use ../config/config.txt
+    config = ConfigParser('config/config.txt')  # To run by pressing play in pycharm, use ../config/config.txt
     consensus_table = config.prefix + config.consensus
     comments_table = config.prefix + config.comments
     molgenis_server = molgenis.Session(config.server)
@@ -41,8 +43,11 @@ def main():
 
     # Generate and upload CSV with consensus table
     file_generator = ConsensusFileGenerator(
-        data={'consensus_data': consensus, 'lab_classifications': lab_classifications, 'history': {'history': sorted_history, 'alternative': alternative_history}},
-        tables={'consensus_table': output + consensus_table, 'comments_table': output + comments_table})
+        data={'consensus_data': consensus, 'lab_classifications': lab_classifications,
+              'history': {'history': sorted_history, 'alternative': alternative_history}},
+        tables={'consensus_table': output + consensus_table, 'comments_table': output + comments_table},
+        incorrect_variant_history_file=output + 'incorrect_variant_history.csv'
+    )
     file_generator.generate_consensus_files()
 
     # Generate reports
@@ -50,6 +55,8 @@ def main():
     csv = '{}/{}consensus.csv'.format(output, prefix)
     public = prefix + 'public_consensus'
     ConsensusReporter(csv, config.labs, public, prefix, output).process_consensus()
+    print('Added incorrect variants in history to [{}]'.format(
+        colored('{}incorrect_variant_history.csv'.format(output), 'blue')))
 
 
 if __name__ == '__main__':

--- a/tests/ConsensusFileGenerator_test.py
+++ b/tests/ConsensusFileGenerator_test.py
@@ -55,3 +55,36 @@ class ConsensusFileGeneratorTest(TestCase):
         export = {'ATP1A2_NM_000702.2:c.2841-19delTinsCT': 'f2941cd0ea'}
         observed = ConsensusFileGenerator._check_alternative_history(transcript, c_dna, gene, export)
         self.assertEqual(observed, 'f2941cd0ea')
+
+    @parameterized.expand([
+        ('variant correct and has transcript:cDNA -> variant is correct',
+         {'id': '00299bb101', 'ref': 'C', 'alt': 'A', 'start': 23634358, 'chromosome': '16', 'gene': 'PALB2',
+          'type': 'sub', 'transcript': 'NM_024675.3', 'c_dna': 'c.2928G>T'}, ['1912_00299bb101']),
+        ('variant correct and has no transcript:cDNA -> variant is correct',
+         {'id': '001759607f', 'ref': 'G', 'alt': 'C', 'start': '108921331', 'chromosome': 'X', 'gene': 'ACSL4',
+          'type': 'sub'}, ['1912_001759607f']),
+        # f2941cd0ea
+        ('variant incorrect and has transcript:cDNA -> merged with correct existing variant',
+         {'id': '6a550d807b', 'ref': 'A', 'alt': 'AC', 'start': '160109408', 'chromosome': '1', 'gene': 'ATP1A2',
+          'type': 'dup', 'transcript': 'NM_000702.2', 'c_dna': 'c.2841-20_2841-19insC'}, ['1912_f2941cd0ea']),
+        ('variant incorrect and has no transcript:cDNA -> new variant',
+         {'id': '6a550d807b', 'ref': 'A', 'alt': 'AC', 'start': '160109408', 'chromosome': '1', 'gene': 'ATP1A2',
+          'type': 'dup'}, [])
+    ])
+    def test___get_matching_history(self, _, variant, expected):
+        file_generator = ConsensusFileGenerator(
+            data={'consensus_data': {},
+                  'lab_classifications': {},
+                  'history': {
+                      'history': {
+                          '1912': ['1912_00299bb101', '1912_001759607f',
+                                   '1912_f2941cd0ea']},
+                      'alternative': {
+                          '1912': {
+                              'ATP1A2_NM_000702.2:c.2841-20_2841-19insC': '1912_f2941cd0ea',
+                              'PALB2_NM_024675.3:c.2928G>T': '1912_00299bb101'}
+                      }}
+                  },
+            tables={'consensus_table': '', 'comments_table': ''})
+        observed = file_generator._get_matching_history(variant)
+        self.assertEqual(observed, expected)

--- a/tests/ConsensusFileGenerator_test.py
+++ b/tests/ConsensusFileGenerator_test.py
@@ -33,7 +33,8 @@ class ConsensusFileGeneratorTest(TestCase):
         ('delins',
          {'variant_id': '3e69715481', 'chromosome': '9', 'pos': '135786871', 'gene': 'TSC1', 'ref': 'GGGGAACTCAGAGT',
           'alt': 'AACTGC', 'variant_type': 'delins'},
-         ['3e69715481', '9_135786871_GGGGAACTCAGAGT_AACTGC_TSC1', '4dd6e4fad5', '4b70f6a705', 'ae3fae1fd2', 'c3d04968bc'])
+         ['3e69715481', '9_135786871_GGGGAACTCAGAGT_AACTGC_TSC1', '4dd6e4fad5', '4b70f6a705', 'ae3fae1fd2',
+          'c3d04968bc'])
     ])
     def test__get_history_ids_for_variant(self, _, variant_info, expected):
         variant_id = variant_info['variant_id']
@@ -46,3 +47,11 @@ class ConsensusFileGeneratorTest(TestCase):
         observed = ConsensusFileGenerator._get_history_ids_for_variant(variant_id, chromosome, pos, ref, alt, gene,
                                                                        variant_type)
         self.assertEqual(observed, expected)
+
+    def test__check_alternative_history(self):
+        transcript = 'NM_000702.2'
+        c_dna = 'c.2841-19delTinsCT'
+        gene = 'ATP1A2'
+        export = {'ATP1A2_NM_000702.2:c.2841-19delTinsCT': 'f2941cd0ea'}
+        observed = ConsensusFileGenerator._check_alternative_history(transcript, c_dna, gene, export)
+        self.assertEqual(observed, 'f2941cd0ea')


### PR DESCRIPTION
Some variants were incorrectly presented:
[https://github.com/molgenis/data-transform-vkgl/issues/14](url)
By fixing this issue, the history of those variants is lost. To fix this as much as possible, we try and find variants with the same gene,c_dna, and transcript to connect the history to the actual variant. For variants that don't have this information, we accept that history is lost. The variants were incorrect and don't make any sense, so we want to keep them out of our database. 
Variants with incorrect names found in previous exports, will be written to a csv file with a nice message. This file can be used to write a script that puts a note in the comments of the invalid variants in the history table telling that the variant is invalid and the id of the correct variant in future releases. 