### PR TITLE
fix(molgenisconfigparser): remove server, user and password as we don't use it anymore

### DIFF
--- a/consensus/MolgenisConfigParser.py
+++ b/consensus/MolgenisConfigParser.py
@@ -1,9 +1,6 @@
 class MolgenisConfigParser:
     def __init__(self, file):
         config = self.parse(file)
-        self.server = config['server']
-        self.username = config['username']
-        self.password = config['password']
         self.prefix = config ['prefix']
         self.consensus= config['consensus']
         self.comments = config['comments']


### PR DESCRIPTION
When you don't specify the server, user and password, you will receive an error, which is incorrect. After this PR not anymore. 

Easy to test running the HistoryWriter (make sure you either first test PR: https://github.com/molgenis/molgenis-py-consensus/pull/20, or run it using the PyCharm play button and specify .../ in front of your input/output files in the config)