### PR TITLE
fix: read config from appropriate folder when running from terminal

### DIFF
--- a/preprocessing/HistoryWriter.py
+++ b/preprocessing/HistoryWriter.py
@@ -68,7 +68,7 @@ class HistoryWriter:
 
 
 def main():
-    config = ConfigParser('../config/config.txt')
+    config = ConfigParser('config/config.txt')
     input_folder = config.input
     output_folder = config.output
     previous = config.previous[-1]

--- a/preprocessing/PreProcessor.py
+++ b/preprocessing/PreProcessor.py
@@ -57,7 +57,7 @@ class PreProcessor:
 
 
 def main():
-    config = ConfigParser('../config/config.txt')
+    config = ConfigParser('config/config.txt')
     input_folder = config.input
     output_folder = config.output
     labs = config.labs


### PR DESCRIPTION
After this PR, you can run the history writer like this:
```
python3 -m venv env
source env/bin/activate
pip install -e .
python3 preprocessing/HistoryWriter.py
```
and preprocessor:
```python3 preprocessing/PreProcessor.py```